### PR TITLE
docs: Remove link with archived content from readme

### DIFF
--- a/packages/firebase_remote_config/firebase_remote_config/README.md
+++ b/packages/firebase_remote_config/firebase_remote_config/README.md
@@ -8,12 +8,9 @@ To learn more about Firebase Remote Config, please visit the [Firebase website](
 
 ## Getting Started
 
-To get started with Firebase Remote Config for Flutter, please [see the documentation](https://firebase.flutter.dev/docs/remote-config/overview) available
-at [https://firebase.flutter.dev](https://firebase.flutter.dev)
-
-## Usage
-
-To use this plugin, please visit the [Firebase Remote Config Usage documentation](https://firebase.google.com/docs/remote-config/get-started?platform=flutter)
+To get started with Firebase Remote Config for Flutter, please
+see the [Flutter specific documentation](https://firebase.google.com/docs/remote-config/get-started?platform=flutter) available at
+[https://firebase.google.com/](https://firebase.google.com/).
 
 ## Issues and feedback
 


### PR DESCRIPTION
## Description

Removing the link to https://firebase.flutter.dev, since it is archived.
Since the "Usage" section ended up pretty much identical to the "Getting started" section, the "Usage" section was removed.

## Related Issues

*Replace this paragraph with a list of issues related to this PR from the [issue database](https://github.com/flutter/flutter/issues). Indicate, which of these issues are resolved or fixed by this PR. Note that you'll have to prefix the issue numbers with flutter/flutter#.*

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
